### PR TITLE
Update message_stream.rs, fix error log when echo client socket close on windows

### DIFF
--- a/src/message_stream.rs
+++ b/src/message_stream.rs
@@ -153,7 +153,13 @@ where
         &mut self,
     ) -> Result<Option<MessageEvent<<A::Handler as Decode>::Item>>> {
         loop {
-            track!(self.rbuf.fill(&mut self.transport_stream))?;
+            match track!(self.rbuf.fill(&mut self.transport_stream)) {
+                Err(_e) => {
+                    //println!("{}", e);
+                    break;
+                }
+                Ok(_r) => {}
+            }
 
             if !self.packet_header_decoder.is_idle() {
                 track!(self


### PR DESCRIPTION
[0] at ~\.cargo\registry\src\github.com-1ecc6299db9ec823\bytecodec-0.4.11\src\io.rs:189
[1] at src\message_stream.rs:156
[2] at src\message_stream.rs:296
[3] at src\server_side_channel.rs:43
[4] at src\rpc_server.rs:360
 , client: 127.0.0.1:56425, server: 127.0.0.1:4567, module: fibers_rpc::rpc_server:322