### PR TITLE
`ServerBuilder::finish` takes `mut self` instead of `&self`

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -122,10 +122,9 @@ fn main() {
     let mut executor = track_try_unwrap!(ThreadPoolExecutor::new().map_err(Failure::from_error));
 
     if let Some(_matches) = matches.subcommand_matches("server") {
-        let server = ServerBuilder::new(addr)
-            .logger(logger)
-            .add_call_handler(EchoHandler)
-            .finish(executor.handle());
+        let mut builder = ServerBuilder::new(addr);
+        builder.logger(logger).add_call_handler(EchoHandler);
+        let server = builder.finish(executor.handle());
         let fiber = executor.spawn_monitor(server);
         let _ = track_try_unwrap!(executor.run_fiber(fiber).map_err(Failure::from_error))
             .map_err(|e| panic!("{}", e));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,9 @@
 //!     }
 //! }
 //! let server_addr = "127.0.0.1:1919".parse().unwrap();
-//! let server = ServerBuilder::new(server_addr)
-//!     .add_call_handler(EchoHandler)
-//!     .finish(fibers_global::handle());
+//! let mut builder = ServerBuilder::new(server_addr);
+//! builder.add_call_handler(EchoHandler);
+//! let server = builder.finish(fibers_global::handle());
 //! fibers_global::spawn(server.map_err(|e| panic!("{}", e)));
 //!
 //! // RPC client
@@ -330,9 +330,9 @@ mod tests {
     #[test]
     fn it_works() -> TestResult {
         // Server
-        let server = ServerBuilder::new("127.0.0.1:0".parse().unwrap())
-            .add_call_handler(EchoHandler)
-            .finish(fibers_global::handle());
+        let mut builder = ServerBuilder::new("127.0.0.1:0".parse().unwrap());
+        builder.add_call_handler(EchoHandler);
+        let server = builder.finish(fibers_global::handle());
         let (server, server_addr) = track!(fibers_global::execute(server.local_addr()))?;
         fibers_global::spawn(server.map_err(|e| panic!("{}", e)));
 
@@ -362,9 +362,9 @@ mod tests {
     #[test]
     fn large_message_works() -> TestResult {
         // Server
-        let server = ServerBuilder::new("127.0.0.1:0".parse().unwrap())
-            .add_call_handler(EchoHandler)
-            .finish(fibers_global::handle());
+        let mut builder = ServerBuilder::new("127.0.0.1:0".parse().unwrap());
+        builder.add_call_handler(EchoHandler);
+        let server = builder.finish(fibers_global::handle());
         // let (server, server_addr) = track!(fibers_global::execute(server.local_addr()))?;
         let future = server.local_addr();
         let (server, server_addr) = track!(fibers_global::execute(future))?;
@@ -385,9 +385,9 @@ mod tests {
     #[test]
     fn async_works() -> TestResult {
         // Server
-        let server = ServerBuilder::new("127.0.0.1:0".parse().unwrap())
-            .add_call_handler(EchoHandler)
-            .finish(fibers_global::handle());
+        let mut builder = ServerBuilder::new("127.0.0.1:0".parse().unwrap());
+        builder.add_call_handler(EchoHandler);
+        let server = builder.finish(fibers_global::handle());
         let (server, server_addr) = track!(fibers_global::execute(server.local_addr()))?;
         fibers_global::spawn(server.map_err(|e| panic!("{}", e)));
 

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -213,7 +213,7 @@ impl ServerBuilder {
     /// Returns the resulting RPC server.
     ///
     /// The invocation of this method consumes all registered handlers.
-    pub fn finish<S>(&mut self, spawner: S) -> Server<S>
+    pub fn finish<S>(mut self, spawner: S) -> Server<S>
     where
         S: Clone + Spawn + Send + 'static,
     {


### PR DESCRIPTION
# Motivation
The crate fibers_rpc plays a central role in systems that are developed on the basis of fibers.
I would like to prevent mistakes such as follows:

```rust
let mut rpc_server_builder = ServerBuilder::new(...);
...
...
...
let rpc_server = rpc_server_builder.finish(fibers_global::handle());
...
...
...
let _ = add_handlers(&mut rpc_server_builder); // since we use the `rpc_server` created above, this line is meaningless
```

When we work on a huge system, it is difficult (or needs a lot of time) to find low-layer mistakes as above stated.

# Change
For my goal, I change as follows:
```rust
// src/rpc_server.rs:
impl ServerBuilder {
    old: pub fn finish<S>(&mut self, spawner: S) -> Server<S>
    new: pub fn finish<S>(mut self, spawner: S) -> Server<S>
}
```

# Benefit
By this change, Rust compiler rejects `let _ = add_handlers(&mut rpc_server_builder)` in the above example at a compile time.

# Note
By this change, `ServerBuilder` becomes a consuming builder.
As convention of Rust, the non-consuming builder pattern is more preferred than consuming one (cf. https://doc.rust-lang.org/1.0.0/style/ownership/builders.html);
However, on this case, I think becoming the consuming builder is natural because we do not add handlers after `ServerBuilder::finish` usually.
