### PR TITLE
Do `cargo test` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
   allow_failures:
     - rust: nightly
 
+script:
+  - cargo test --all
+
 env:
   global:
   - RUSTFLAGS="-C link-dead-code"


### PR DESCRIPTION
The current fibers_rpc has test codes in `lib.rs`; therefore, we'd be happy if we could do `cargo test` on Travis !!
