### PR TITLE
Don't call ExponentialBackoff::next in force_wakeup

### DIFF
--- a/src/client_side_channel.rs
+++ b/src/client_side_channel.rs
@@ -70,7 +70,9 @@ impl ClientSideChannel {
     pub fn force_wakeup(&mut self) {
         if let MessageStreamState::Wait { .. } = self.message_stream {
             info!(self.logger, "Waked up");
-            self.exponential_backoff.next();
+            // We don't multiply `timeout` by 2 here because it would cause
+            // arithmetic overflow on Duration/Instant computation
+            // if this function is repeatedly called.
             let next = MessageStreamState::Connecting {
                 buffer: Vec::new(),
                 future: tcp_connect(self.server, &self.options),


### PR DESCRIPTION
A bugfix to prevent `ClientSideChannel` from panicking when connection is unstable.

Discussion: [gitter (frugalos/development)](https://gitter.im/frugalos/development?at=5f52102c59ac794e02e8bd6a) (in Japanese language)